### PR TITLE
move secrets from stack-specific KMS keys to common KMS keys

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -18,4 +18,4 @@ parameters:
   Env: develop
   NewRelicAppName: bridgeserver2-develop
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-develop/SSLCertArn
+  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -18,4 +18,3 @@ parameters:
   Env: develop
   NewRelicAppName: bridgeserver2-develop
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -18,4 +18,3 @@ parameters:
   Env: production
   NewRelicAppName: bridgeserver2-prod
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -18,4 +18,4 @@ parameters:
   Env: production
   NewRelicAppName: bridgeserver2-prod
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-prod/SSLCertArn
+  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -18,4 +18,3 @@ parameters:
   Env: staging
   NewRelicAppName: bridgeserver2-uat
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -18,4 +18,4 @@ parameters:
   Env: staging
   NewRelicAppName: bridgeserver2-uat
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
-  SSLCertArn: !ssm /bridgeserver2-uat/SSLCertArn
+  SSLCertArn: !ssm /bridgeserver2-common/SSLCertArn

--- a/templates/bridgeserver2-common.yaml
+++ b/templates/bridgeserver2-common.yaml
@@ -1,10 +1,29 @@
 Description: Common resources for all stacks of BridgeServer2 Application
 AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  DNSDomainName:
+    Description: DNS Domain name for Bridge Server
+    Type: String
+    Default: 'sagebridge.org'
 Resources:
   BeanstalkApplication:
     Type: 'AWS::ElasticBeanstalk::Application'
     Properties:
       ApplicationName: 'BridgeServer2-application'
+  SSLCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Join
+        - '.'
+        - - '*'
+          - !Ref DNSDomainName
+      DomainValidationOptions:
+        - DomainName: !Join
+            - '.'
+            - - '*'
+              - !Ref DNSDomainName
+          ValidationDomain: !Ref DNSDomainName
+      ValidationMethod: DNS
   # KMS Keys
   AWSKmsKey:
     Type: "AWS::KMS::Key"
@@ -73,6 +92,10 @@ Outputs:
     Value: !Ref BeanstalkApplication
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-BeanstalkAppName'
+  SSLCertificate:
+    Value: !Ref SSLCertificate
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSLCertificate'
   AWSKmsKey:
     Value: !Ref AWSKmsKey
     Export:

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -88,9 +88,6 @@ Parameters:
       - Rolling
       - RollingWithAdditionalBatch
       - Immutable
-  SSLCertArn:
-    Description: SSL certificate for load balancer
-    Type: String
 Conditions:
   CreateDevResources: !Equals [ !Ref BridgeEnv, dev ]
 Resources:
@@ -213,7 +210,7 @@ Resources:
           Value: HTTPS
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: SSLCertificateArns
-          Value: !Ref SSLCertArn
+          Value: !ImportValue us-east-1-bridgeserver2-common-SSLCertificate
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: ENV


### PR DESCRIPTION
CloudFormation doesn't update Route53 Health Checks when you update the template. In order to fix this, I decided to delete and recreate the stacks. I discovered a circular dependencies, where we get the SSLCert from the KMS Key that the CloudFormation template then creates.

In order to fix this circular dependency, I moved the SSL Cert from the stack-specific KMS keys to the common one.