### PR TITLE
[IT-435] upgrade to use Sceptre ver 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,7 @@ git-crypt.key
 !.elasticbeanstalk/*.global.yml
 
 # sceptre artifacts
-remote-templates
-resolvers
+templates/remote
 
 # lambda artifacts
 lambdas/*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: 3.5
+python: 3.6
 cache: pip
 fast_finish: true
 branches:
@@ -9,11 +9,13 @@ branches:
   - uat
   - prod
 install:
-  - pip install cfn-lint
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - ./setup_sceptre.sh || travis_terminate 1
+  - pip install cfn-lint
+  - pip install git+git://github.com/zaro0508/sceptre@issue-586
+  - pip install git+git://github.com/zaro0508/sceptre-ssm-resolver.git
+  - pip install git+git://github.com/zaro0508/sceptre-date-resolver.git
 stages:
   - name: validate
   - name: deploy
@@ -21,8 +23,8 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint ./templates/**/*.yaml
+      script: cfn-lint ./templates/**/*
     - stage: deploy
       script:
-        - sceptre --var "profile=default" --var "region=us-east-1" launch-env common
-        - sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
+        - sceptre launch common --yes
+        - sceptre launch $TRAVIS_BRANCH --yes

--- a/config/common/bridgeserver2-common.yaml
+++ b/config/common/bridgeserver2-common.yaml
@@ -1,2 +1,2 @@
-template_path: templates/bridgeserver2-common.yaml
+template_path: bridgeserver2-common.yaml
 stack_name: bridgeserver2-common

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,3 +3,4 @@ profile: {{ var.profile | default("default") }}
 region: {{ var.region | default("us-east-1") }}
 template_bucket_name: bootstrap-awss3cloudformationbucket-zov6lb1ge7ll
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
+admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"

--- a/config/develop/bridgeserver2-dashboard.yaml
+++ b/config/develop/bridgeserver2-dashboard.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2-dashboard.yaml
+template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-develop
 parameters:
   AwsAutoScalingGroupName: awseb-e-q6pn22tu2e-stack-AWSEBAutoScalingGroup-19IYJMG53IKW7

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2.yaml
+template_path: bridgeserver2.yaml
 stack_name: bridgeserver2-develop
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-develop

--- a/config/prod/bridgeserver2-dashboard.yaml
+++ b/config/prod/bridgeserver2-dashboard.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2-dashboard.yaml
+template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-prod
 parameters:
   AwsAutoScalingGroupName: awseb-e-qurzpmckku-stack-AWSEBAutoScalingGroup-DW4HNTEIUMLP

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2.yaml
+template_path: bridgeserver2.yaml
 stack_name: bridgeserver2-prod
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-prod

--- a/config/uat/bridgeserver2-dashboard.yaml
+++ b/config/uat/bridgeserver2-dashboard.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2-dashboard.yaml
+template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-uat
 parameters:
   AwsAutoScalingGroupName: awseb-e-wpygkt3rxe-stack-AWSEBAutoScalingGroup-1713G6ZQQVZ9Q

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridgeserver2.yaml
+template_path: bridgeserver2.yaml
 stack_name: bridgeserver2-uat
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-uat


### PR DESCRIPTION
Upgrade from Sceptre 1.x to 2.x because V1 is end of life[1].
Followed the migration guide[2] to do the upgrade.

[1] cloudreach/sceptre#593
[2] https://github.com/cloudreach/sceptre/wiki/Migration-Guide:-V1-to-V2