### PR TITLE
Add cross-VPC security group for RDS

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -340,6 +340,20 @@ Resources:
       Tier:
         Name: WebServer
         Type: Standard
+  AWSEC2RdsSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - AWSEC2RdsSecurityGroup
+      # RDS lives in a different VPC (for now)
+      VpcId: 'vpc-9c70bbf9'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3306
+          ToPort: 3306
+          SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
   AWSEC2SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
RDS lives in the BridgePF VPC (the default VPC). We need to set up a security group in the default VPC which can accept requests from the Server2 security group (in the other VPC; VPC peering has already been set up elsewhere).