### PR TITLE
add AttachmentBucket policy to enable Synapse External S3 Buckets

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -3,6 +3,7 @@ stack_name: bridgeserver2-develop
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-develop
   AppHealthcheckUrl: '/'
+  AttachmentBucket: org-sagebridge-attachment-develop
   AwsAutoScalingMaxSize: '1'
   AwsAutoScalingMinSize: '1'
   AwsEbHealthReportingSystem: enhanced

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -3,6 +3,7 @@ stack_name: bridgeserver2-prod
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-prod
   AppHealthcheckUrl: '/'
+  AttachmentBucket: org-sagebridge-attachment-prod
   AwsAutoScalingMaxSize: "2"
   AwsAutoScalingMinSize: "2"
   AwsEbHealthReportingSystem: enhanced

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -3,6 +3,7 @@ stack_name: bridgeserver2-uat
 parameters:
   AppDeployBucket: org-sagebridge-bridgeserver2-deployment-uat
   AppHealthcheckUrl: '/'
+  AttachmentBucket: org-sagebridge-attachment-uat
   AwsAutoScalingMaxSize: '1'
   AwsAutoScalingMinSize: '1'
   AwsEbHealthReportingSystem: enhanced

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -6,6 +6,8 @@ Parameters:
   AppHealthcheckUrl:
     Type: String
     Description: The AWS EB health check path
+  AttachmentBucket:
+    Type: String
   AwsAutoScalingMaxSize:
     Type: String
     Default: '1'
@@ -932,6 +934,36 @@ Resources:
           - !Ref AWS::StackName
           - '/KmsKey'
       TargetKeyId: !Ref AWSKmsKey
+  SynapseExternalStoragePolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: AttachmentBucket
+      PolicyDocument:
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref AttachmentBucket
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:GetObject*"
+              - "s3:*MultipartUpload*"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref AttachmentBucket
+                  - "/*"
 Outputs:
   AppPublicEndpoint:
     Value: !Join


### PR DESCRIPTION
This change is needed to use External S3 Buckets in Synapse. See also https://sagebionetworks.jira.com/browse/BRIDGE-2414