### PR TITLE
ignore Hibernate in error alarm

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -513,7 +513,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/tomcat8/catalina.out
-      FilterPattern: 'ERROR'
+      FilterPattern: 'ERROR - org.hibernate'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
Hibernate alarms are noisy and generally useless. Ignore them in alarms.