### PR TITLE
remove old elasticache

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -19,7 +19,6 @@ parameters:
   AwsSnsNotificationEndpoint: bridgepf-develop@sagebase.org
   BridgeEnv: dev
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-develop/BridgeHealthcodeRedisKey
-  BridgePFStackName: bridgepf-develop
   BridgeUser: heroku
   DNSHostname: bridgeserver2-develop
   DNSDomain: sagebridge.org

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -19,7 +19,6 @@ parameters:
   AwsSnsNotificationEndpoint: bridgeops@sagebase.org
   BridgeEnv: prod
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-prod/BridgeHealthcodeRedisKey
-  BridgePFStackName: bridgepf-prod
   BridgeUser: heroku
   DNSHostname: bridgeserver2-prod
   DNSDomain: sagebridge.org

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -19,7 +19,6 @@ parameters:
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
   BridgeEnv: uat
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-uat/BridgeHealthcodeRedisKey
-  BridgePFStackName: bridgepf-uat
   BridgeUser: heroku
   DNSHostname: bridgeserver2-uat
   DNSDomain: sagebridge.org

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -58,9 +58,6 @@ Parameters:
   BridgeHealthcodeRedisKey:
     Type: String
     NoEcho: true
-  BridgePFStackName:
-    Type: String
-    Description: Name of the corresponding BridgePF stack. Used to import Elasticache and RDS until we can properly migrate them.
   BridgeUser:
     Type: String
     Default: heroku
@@ -310,8 +307,12 @@ Resources:
               - !GetAtt ElasticacheCluster.RedisEndpoint.Port
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: elasticache.url
-          Value:
-            Fn::ImportValue: !Sub "${BridgePFStackName}-ElastiCacheUrl"
+          Value: !Join
+            - ''
+            - - 'redis://'
+              - !GetAtt ElasticacheCluster.RedisEndpoint.Address
+              - ':'
+              - !GetAtt ElasticacheCluster.RedisEndpoint.Port
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: email.unsubscribe.token
           Value: !Ref EmailUnsubscribeToken


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2508

Remove reference to the old Elasticache imported from BridgePF-infra. As a stopgap solution, both elasticache.url and elasticache.new.url point to the same Elasticache instance. This is so that in the few minutes between pushing Server2-infra and Server2, Server2 still runs in a reasonable manner. This has been tested.