### PR TITLE
Increase max heap size to 1024mb. Set rolling deployment options to 1 host at a time

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -189,6 +189,12 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:command'
           OptionName: DeploymentPolicy
           Value: !Ref RollingUpdateDeploymentPolicy
+        - Namespace: 'aws:elasticbeanstalk:command'
+          OptionName: BatchSizeType
+          Value: 'Fixed'
+        - Namespace: 'aws:elasticbeanstalk:command'
+          OptionName: BatchSize
+          Value: '1'
         - Namespace: 'aws:ec2:vpc'
           OptionName: ELBSubnets
           Value: !Join
@@ -224,6 +230,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:container:tomcat:jvmoptions'
           OptionName: JVM Options
           Value: '-Dnewrelic.config.file=/etc/newrelic.yml -javaagent:/usr/local/lib/newrelic/newrelic-agent.jar'
+        - Namespace: 'aws:elasticbeanstalk:container:tomcat:jvmoptions'
+          OptionName: Xmx
+          Value: '1024m'
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
           Value: !ImportValue us-east-1-bridgeserver2-common-BeanstalkServiceRole


### PR DESCRIPTION
This fixes 2 issues:

1. Elastic Beanstalk defaults max heap size to 256mb (https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-specific.html#command-options-java). We use t2.smalls (t2.mediums in Prod), which have 2gb of RAM. We're getting OutOfMemoryErrors quite frequently. I increased the heap size to 1024mb, since we have a lot of extra RAM to work with. This might also be why our Prod host died last week.

2. There are two kinds of rolling deployment, one for application code, one for configuration. The configuration rolling deployment was configured correctly, but the application deployment was set to 100% of hosts at a time, which is bad. This fixes that.