### PR TITLE
Fix EnvironmentHealth alarm

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -741,9 +741,13 @@ Resources:
       EvaluationPeriods: 1
       MetricName: EnvironmentHealth
       Namespace: AWS/ElasticBeanstalk
-      Period: 900
-      Statistic: Maximum
-      Threshold: 25
+      Dimensions:
+        - Name: "EnvironmentName"
+          Value: !Ref 'AWS::StackName'
+      Period: 3600
+      Statistic: Average
+      # Note: 20 is "warning", which can happen if an entire host is down.
+      Threshold: 20
   AWSCWHealthCheckStatusAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2535

Two problems with this alarm:

1. It uses the wrong metric.
2. A box can be entirely down and Elastic Beanstalk registers it as "warning", which is 20. So I set the threshold to 20.

This has been tested in Dev.