### PR TITLE
Adding Synapse OAuth client to Bridge server configuration environment

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -38,3 +38,5 @@ parameters:
   SnsSecretKey: !ssm /bridgeserver2-develop/SnsSecretKey
   SynapseApiKey: !ssm /bridgeserver2-develop/SynapseApiKey
   SynapseUser: !ssm /bridgeserver2-develop/SynapseUser
+  SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
+  SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -38,5 +38,5 @@ parameters:
   SnsSecretKey: !ssm /bridgeserver2-prod/SnsSecretKey
   SynapseApiKey: !ssm /bridgeserver2-prod/SynapseApiKey
   SynapseUser: !ssm /bridgeserver2-prod/SynapseUser
-  SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
-  SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret
+  SynapseOAuthClientId: !ssm /bridgeserver2-prod/SynapseOAuthClientId
+  SynapseOAuthClientSecret: !ssm /bridgeserver2-prod/SynapseOAuthClientSecret

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -38,3 +38,5 @@ parameters:
   SnsSecretKey: !ssm /bridgeserver2-prod/SnsSecretKey
   SynapseApiKey: !ssm /bridgeserver2-prod/SynapseApiKey
   SynapseUser: !ssm /bridgeserver2-prod/SynapseUser
+  SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
+  SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -38,3 +38,5 @@ parameters:
   SnsSecretKey: !ssm /bridgeserver2-uat/SnsSecretKey
   SynapseApiKey: !ssm /bridgeserver2-uat/SynapseApiKey
   SynapseUser: !ssm /bridgeserver2-uat/SynapseUser
+  SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
+  SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -38,5 +38,5 @@ parameters:
   SnsSecretKey: !ssm /bridgeserver2-uat/SnsSecretKey
   SynapseApiKey: !ssm /bridgeserver2-uat/SynapseApiKey
   SynapseUser: !ssm /bridgeserver2-uat/SynapseUser
-  SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
-  SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret
+  SynapseOAuthClientId: !ssm /bridgeserver2-uat/SynapseOAuthClientId
+  SynapseOAuthClientSecret: !ssm /bridgeserver2-uat/SynapseOAuthClientSecret

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -136,6 +136,13 @@ Parameters:
     NoEcho: true
   SynapseUser:
     Type: String
+  SynapseOAuthClientId:
+    Type: String
+    Description: The OAuth client registered with Synapse that enables BSM sign in via Synapse
+  SynapseOAuthClientSecret:
+    Type: String
+    NoEcho: true
+    Description: The OAuth client registered with Synapse that enables BSM sign in via Synapse
 Conditions:
   CreateDevResources: !Equals [ !Ref BridgeEnv, dev ]
 Resources:
@@ -361,6 +368,12 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: synapse.user
           Value: !Ref SynapseUser
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: synapse.oauth.client.id
+          Value: !Ref SynapseOAuthClientId
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: synapse.oauth.client.secret
+          Value: !Ref SynapseOAuthClientSecret
   AWSEBEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
When the Bridge Study Manager redirects to Synapse in order for a user to sign in using their Synapse credentials, a "client" must be registered with Synapse that gives Synapse permission to perform the authentication. There are three clients based on the "callback url" that has to be registered with every client, and that callback URL differs for the three environments where the study manager runs: 127.0.0.1, research-staging.sagebridge.org, and research.sagebridge.org.

The clients already exist on Synapse, but we need to pass the ID and client secret per environment to the server, which performs a second contact of Synapse to complete the authentication and validate the user's identity.