### PR TITLE
[BRIDGE-2452] configure https redirect at the ALB

### DIFF
--- a/config/develop/bridgeserver2-https-redirect.yaml
+++ b/config/develop/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,6 @@
+template_path: bridgeserver2-https-redirect.yaml
+stack_name: bridgeserver2-https-redirect-develop
+depedencies:
+  - develop/bridgeserver2.yaml
+parameters:
+  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:649232250620:loadbalancer/app/awseb-AWSEB-10R081Z8BDQYB/dbd3eb5feb13b1e0"

--- a/config/prod/bridgeserver2-https-redirect.yaml
+++ b/config/prod/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,6 @@
+template_path: bridgeserver2-https-redirect.yaml
+stack_name: bridgeserver2-https-redirect-prod
+depedencies:
+  - prod/bridgeserver2.yaml
+parameters:
+  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:649232250620:loadbalancer/app/awseb-AWSEB-8IYQI4F40LAM/6216119ed73ce6eb"

--- a/config/uat/bridgeserver2-https-redirect.yaml
+++ b/config/uat/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,6 @@
+template_path: bridgeserver2-https-redirect.yaml
+stack_name: bridgeserver2-https-redirect-uat
+depedencies:
+  - uat/bridgeserver2.yaml
+parameters:
+  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:649232250620:loadbalancer/app/awseb-AWSEB-1SRC5HKN6BHKG/5c45c9f5394e80bd"

--- a/templates/bridgeserver2-https-redirect.yaml
+++ b/templates/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,26 @@
+Description: Load balancer HTTPS redirect
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  LoadBalancerArn:
+    Type: String
+Resources:
+  HttpsRedirectListener:
+     Type: "AWS::ElasticLoadBalancingV2::Listener"
+     Properties:
+       DefaultActions:
+         - Type: "redirect"
+           RedirectConfig:
+             Protocol: "HTTPS"
+             Port: "443"
+             Host: "#{host}"
+             Path: "/#{path}"
+             Query: "#{query}"
+             StatusCode: "HTTP_301"
+       LoadBalancerArn: !Ref LoadBalancerArn
+       Port: 80
+       Protocol: "HTTP"
+Outputs:
+  HttpsRedirectListener:
+    Value: !Ref HttpsRedirectListener
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-HttpsRedirectListener'


### PR DESCRIPTION
Use the AWS application load balancer to handle https redirect.
This is not a great solution because we don't have a way to
automatically inject the LoadBalancerArn into the template.
AWS Beanstalk does not provide a reference or option to configure
the ALB that it provisions.  This implementation requires us to
manually look up the ALB Arn post beanstalk deployment and pass
the Arn to the template.