### PR TITLE
Fix cloudformation dependencies

### DIFF
--- a/config/develop/bridgeserver2-dashboard.yaml
+++ b/config/develop/bridgeserver2-dashboard.yaml
@@ -1,5 +1,7 @@
 template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-develop
+depedencies:
+  - develop/bridgeserver2.yaml
 parameters:
   AwsAutoScalingGroupName: awseb-e-q6pn22tu2e-stack-AWSEBAutoScalingGroup-19IYJMG53IKW7
   AwsLoadBalancerName: awseb-AWSEB-10R081Z8BDQYB/dbd3eb5feb13b1e0

--- a/config/prod/bridgeserver2-dashboard.yaml
+++ b/config/prod/bridgeserver2-dashboard.yaml
@@ -1,5 +1,7 @@
 template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-prod
+depedencies:
+  - prod/bridgeserver2.yaml
 parameters:
   AwsAutoScalingGroupName: awseb-e-qurzpmckku-stack-AWSEBAutoScalingGroup-DW4HNTEIUMLP
   AwsLoadBalancerName: awseb-AWSEB-8IYQI4F40LAM/6216119ed73ce6eb

--- a/config/uat/bridgeserver2-dashboard.yaml
+++ b/config/uat/bridgeserver2-dashboard.yaml
@@ -1,5 +1,7 @@
 template_path: bridgeserver2-dashboard.yaml
 stack_name: bridgeserver2-dashboard-uat
+depedencies:
+  - uat/bridgeserver2.yaml
 parameters:
   AwsAutoScalingGroupName: awseb-e-wpygkt3rxe-stack-AWSEBAutoScalingGroup-1713G6ZQQVZ9Q
   AwsLoadBalancerName: awseb-AWSEB-1SRC5HKN6BHKG/5c45c9f5394e80bd


### PR DESCRIPTION
The dashbaord template references the ALB which is deployed by
beanstalk in the main bridgeserver2 template. Therefore sceptre
must deploy beanstalk (with ALB) before setting up the dashboard.