### PR TITLE
Add Exporter 3.0 buckets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint ./templates/**/*
+      script: cfn-lint -i E3012 -- ./templates/**/*
     - stage: deploy
       script:
         - sceptre launch common --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint -i E3012 -- ./templates/**/*
+      script: cfn-lint ./templates/**/*
     - stage: deploy
       script:
         - sceptre launch common --yes

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -335,6 +335,12 @@ Resources:
           OptionName: email.unsubscribe.token
           Value: !Ref EmailUnsubscribeToken
         - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: health.data.bucket.processed
+          Value: !Ref ProcessedHealthDataBucket
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: health.data.bucket.raw
+          Value: !Ref RawHealthDataBucket
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: hibernate.connection.password
           Value: !Ref HibernateConnectionPassword
         - Namespace: 'aws:elasticbeanstalk:application:environment'
@@ -469,6 +475,12 @@ Resources:
       BucketName: !Ref AppDeployBucket
   AWSR53RecordSet:
     Type: 'AWS::Route53::RecordSet'
+    # This check is bugged. See https://github.com/aws-cloudformation/cfn-python-lint/issues/1425
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3012
     Properties:
       HostedZoneName: !Join
         - ''
@@ -768,6 +780,13 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: 3000
   RawHealthDataBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -806,6 +825,13 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: 3000
   ProcessedHealthDataBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -787,6 +787,8 @@ Resources:
             AllowedOrigins: ['*']
             AllowedMethods: [GET, POST, PUT, HEAD]
             MaxAge: 3000
+      VersioningConfiguration:
+        Status: Enabled
   RawHealthDataBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -832,6 +834,8 @@ Resources:
             AllowedOrigins: ['*']
             AllowedMethods: [GET, POST, PUT, HEAD]
             MaxAge: 3000
+      VersioningConfiguration:
+        Status: Enabled
   ProcessedHealthDataBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -759,6 +759,83 @@ Resources:
       Period: 300
       Statistic: Average
       Threshold: 1
+  # Bucket for raw health data. Grant Synapse read-only permissions to this bucket. Only Bridge can
+  # write to thise bucket.
+  RawHealthDataBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+  RawHealthDataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: RawHealthDataBucket
+      PolicyDocument:
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref RawHealthDataBucket
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:GetObject*"
+              - "s3:*MultipartUpload*"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref RawHealthDataBucket
+                  - "/*"
+  # Bucket for processed health data. Grant Synapse read-write permissions to this bucket.
+  ProcessedHealthDataBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+  ProcessedHealthDataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: ProcessedHealthDataBucket
+      PolicyDocument:
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref ProcessedHealthDataBucket
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::325565585839:root"
+            Action:
+              - "s3:*Object*"
+              - "s3:*MultipartUpload*"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref ProcessedHealthDataBucket
+                  - "/*"
   IAMBridgeServer2ECManagedPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2599

This creates the buckets that will be used by Bridge Exporter 3.0. Add Bucket Policy to make these buckets accessible to Synapse.

Main design doc at https://docs.google.com/document/d/1RQEjcbpqGu02CLYyxZaFg9wjXMwHisUmze2puM7vq4M/edit?usp=sharing