### PR TITLE
BRIDGE-2122: Use cryptographically strong TLS protocol

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -278,6 +278,13 @@ Resources:
         - Namespace: 'aws:elbv2:listener:443'
           OptionName: SSLCertificateArns
           Value: !ImportValue us-east-1-bridgeserver2-common-SSLCertificate
+        # ELB cipher and TLS protocol versions
+        - Namespace: 'aws:elb:listener:443'
+          OptionName: PolicyNames
+          Value: TLSHighPolicy
+        - Namespace:  'aws:elb:policies:TLSHighPolicy'
+          OptionName: SSLReferencePolicy
+          Value: ELBSecurityPolicy-TLS-1-2-2017-01
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: aws.key


### PR DESCRIPTION
By default AWS load balancers use TLSv1.0.  Our security auditor
recommends disabling the use of TLSv1.0 protocol in favor of a
cryptographically stronger TLSv1.2 protocol.

Note- TLS1.0 is compatible with a broader set of clients
(such as web browsers, mobile devices, and point-of-sale systems).

References:
https://aws.amazon.com/blogs/security/how-to-control-tls-ciphers-in-your-aws-elastic-beanstalk-application-by-using-aws-cloudformation/
https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html