### PR TITLE
[BRIDGE-2887] give sumologic access to briddge beanstalk bucket

### DIFF
--- a/config/prod/BridgeServer2-prod-sumo-role-beanstalk.yaml
+++ b/config/prod/BridgeServer2-prod-sumo-role-beanstalk.yaml
@@ -1,0 +1,11 @@
+template_path: remote/sumologic-role.yaml
+stack_name: BridgeServer2-prod-sumo-role-beanstalk
+dependencies:
+  - prod/essentials.yaml
+parameters:
+  ExternalID: !ssm /infra/SumologicExternalID
+  Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
+  Resource: "arn:aws:s3:::elasticbeanstalk-us-east-1-649232250620"
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"


### PR DESCRIPTION
Setup a role to allow sumologic to ingest Bridge server beanstalk logs.