### PR TITLE
Temporarily remove HTTPS Redirect for dev and staging

### DIFF
--- a/config/develop/bridgeserver2-https-redirect.yaml
+++ b/config/develop/bridgeserver2-https-redirect.yaml
@@ -1,6 +1,0 @@
-template_path: bridgeserver2-https-redirect.yaml
-stack_name: bridgeserver2-https-redirect-develop
-depedencies:
-  - develop/bridgeserver2.yaml
-parameters:
-  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:649232250620:loadbalancer/app/awseb-AWSEB-10R081Z8BDQYB/dbd3eb5feb13b1e0"

--- a/config/uat/bridgeserver2-https-redirect.yaml
+++ b/config/uat/bridgeserver2-https-redirect.yaml
@@ -1,6 +1,0 @@
-template_path: bridgeserver2-https-redirect.yaml
-stack_name: bridgeserver2-https-redirect-uat
-depedencies:
-  - uat/bridgeserver2.yaml
-parameters:
-  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:649232250620:loadbalancer/app/awseb-AWSEB-1SRC5HKN6BHKG/5c45c9f5394e80bd"


### PR DESCRIPTION
I mentioned I was temporarily disabling HTTPS Redirect in the AWS Migration (https://github.com/Sage-Bionetworks/BridgeServer2-infra/pull/44). However, I forgot to disable the CF stacks for HTTPS Redirect in Dev and Staging.