### PR TITLE
re-enable HTTPS Redirect

### DIFF
--- a/config/develop/bridgeserver2-https-redirect.yaml
+++ b/config/develop/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,6 @@
+template_path: bridgeserver2-https-redirect.yaml
+stack_name: bridgeserver2-https-redirect-develop
+depedencies:
+  - develop/bridgeserver2.yaml
+parameters:
+  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:420786776710:loadbalancer/app/awseb-AWSEB-1G9D7P31V0KF8/1c1c11a517077bd2"

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -41,7 +41,6 @@ parameters:
   SynapseOAuthClientId: !ssm /bridgeserver2-develop/SynapseOAuthClientId
   SynapseOAuthClientSecret: !ssm /bridgeserver2-develop/SynapseOAuthClientSecret
   UddSqsQueueUrl: https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-WorkerPlatform-Request-develop
-  UseHttpsForwarding: 'false'
   CrcGeoCodeApiKey: !ssm /bridgeserver2-develop/CrcGeoCodeApiKey
   CuimcTestUsername: !ssm /bridgeserver2-common/CuimcTestUsername
   CuimcTestPassword: !ssm /bridgeserver2-common/CuimcTestPassword

--- a/config/uat/bridgeserver2-https-redirect.yaml
+++ b/config/uat/bridgeserver2-https-redirect.yaml
@@ -1,0 +1,6 @@
+template_path: bridgeserver2-https-redirect.yaml
+stack_name: bridgeserver2-https-redirect-uat
+depedencies:
+  - uat/bridgeserver2.yaml
+parameters:
+  LoadBalancerArn: "arn:aws:elasticloadbalancing:us-east-1:420786776710:loadbalancer/app/awseb-AWSEB-945U6QS9NU6D/7adec35a2101eb3f"

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -41,7 +41,6 @@ parameters:
   SynapseOAuthClientId: !ssm /bridgeserver2-uat/SynapseOAuthClientId
   SynapseOAuthClientSecret: !ssm /bridgeserver2-uat/SynapseOAuthClientSecret
   UddSqsQueueUrl: https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-WorkerPlatform-Request-staging
-  UseHttpsForwarding: 'false'
   CrcGeoCodeApiKey: !ssm /bridgeserver2-uat/CrcGeoCodeApiKey
   CuimcTestUsername: !ssm /bridgeserver2-common/CuimcTestUsername
   CuimcTestPassword: !ssm /bridgeserver2-common/CuimcTestPassword


### PR DESCRIPTION
We disabled HTTPS Redirect as part of the AWS Migration. Now that we've set the DNS entries, we can re-enable HTTPS Redirect again.