### PR TITLE
[BRIDGE-2122] Fix beanstalk load balancer SSL policy

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -310,11 +310,8 @@ Resources:
           OptionName: SSLCertificateArns
           Value: !ImportValue us-east-1-bridgeserver2-common-SSLCertificate
         # ELB cipher and TLS protocol versions
-        - Namespace: 'aws:elb:listener:443'
-          OptionName: PolicyNames
-          Value: TLSHighPolicy
-        - Namespace:  'aws:elb:policies:TLSHighPolicy'
-          OptionName: SSLReferencePolicy
+        - Namespace: 'aws:elbv2:listener:443'
+          OptionName: SSLPolicy
           Value: ELBSecurityPolicy-TLS-1-2-2017-01
         # Application environment options
         - Namespace: 'aws:elasticbeanstalk:application:environment'


### PR DESCRIPTION
The SSL policy namespace was set to `aws:elb` which is used to
set a classic load balancer.  Our beanstalk uses an application
load balancer which uses the namepsace `aws:elbv2`