### PR TITLE
BRIDGE-3166 Upgrade from t2 instances to t3a instances

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -25,7 +25,7 @@ parameters:
   BucketSuffix: devdevelop
   DNSHostname: bridgeserver2-devdevelop
   DNSDomain: sagebridge.org
-  EC2InstanceType: t2.small
+  EC2InstanceType: t3a.small
   EmailUnsubscribeToken: !ssm /bridgeserver2-common/EmailUnsubscribeToken
   Env: develop
   ExporterRequestSqsQueueUrl: https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-EX-Request-develop

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -25,7 +25,7 @@ parameters:
   BucketSuffix: prod
   DNSHostname: bridgeserver2-prod
   DNSDomain: sagebridge.org
-  EC2InstanceType: t2.medium
+  EC2InstanceType: t3a.medium
   EmailUnsubscribeToken: !ssm /bridgeserver2-common/EmailUnsubscribeToken
   Env: production
   ExporterRequestSqsQueueUrl: https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -25,7 +25,7 @@ parameters:
   BucketSuffix: devstaging
   DNSHostname: bridgeserver2-devstaging
   DNSDomain: sagebridge.org
-  EC2InstanceType: t2.small
+  EC2InstanceType: t3a.small
   EmailUnsubscribeToken: !ssm /bridgeserver2-common/EmailUnsubscribeToken
   Env: staging
   ExporterRequestSqsQueueUrl: https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-EX-Request-staging

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -90,14 +90,6 @@ Parameters:
     Type: String
     Description: Instance type to use for Elastic Beanstalk Instances
     Default: t2.small
-    AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - t2.xlarge
-      - t2.2xlarge
   EmailUnsubscribeToken:
     Type: String
     NoEcho: true


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3166

t3a instances have the same performance as t2 but are 18% cheaper. (t4g's are available in ec2, but not yet available in CloudFormation.)

We also remove the list of valid InstanceTypes, since there's not really a reason for us to enumerate them all in our templates.