### PR TITLE
Remove unused environment variables for integration test accounts

### DIFF
--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -12,8 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-develop-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-develop@sagebase.org
-  BootstrapAdminEmail: !ssm /bridgeserver2-develop/BootstrapAdminEmail
-  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-develop/BootstrapAdminSynapseUserId
+  BootstrapAdminPassword: !ssm /bridgeserver2-develop/Password
   BridgeEnv: dev
   BridgeDBStackName: bridgeserver2-db-develop
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-develop/BridgeHealthcodeRedisKey

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -13,11 +13,7 @@ parameters:
   AwsSnsBounceNotificationEndpoint: bridgepf-develop-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-develop@sagebase.org
   BootstrapAdminEmail: !ssm /bridgeserver2-develop/BootstrapAdminEmail
-  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
-  BootstrapApiEmail: !ssm /bridgeserver2-develop/BootstrapApiEmail
-  BootstrapApiPassword: !ssm /bridgeserver2-develop/BootstrapApiPassword
-  BootstrapSharedEmail: !ssm /bridgeserver2-develop/BootstrapSharedEmail
-  BootstrapSharedPassword: !ssm /bridgeserver2-develop/BootstrapSharedPassword
+  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-develop/BootstrapAdminSynapseUserId
   BridgeEnv: dev
   BridgeDBStackName: bridgeserver2-db-develop
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-develop/BridgeHealthcodeRedisKey

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -12,6 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-develop-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-develop@sagebase.org
+  BootstrapAdminEmail: !ssm /bridgeserver2-develop/BootstrapAdminEmail
   BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
   BridgeEnv: dev
   BridgeDBStackName: bridgeserver2-db-develop

--- a/config/develop/bridgeserver2.yaml
+++ b/config/develop/bridgeserver2.yaml
@@ -12,7 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-develop-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-develop@sagebase.org
-  BootstrapAdminPassword: !ssm /bridgeserver2-develop/Password
+  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
   BridgeEnv: dev
   BridgeDBStackName: bridgeserver2-db-develop
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-develop/BridgeHealthcodeRedisKey

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -12,7 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridge-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgeops@sagebase.org
-  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
+  BootstrapAdminPassword: !ssm /bridgeserver2-prod/BootstrapAdminPassword
   BridgeEnv: prod
   BridgeDBStackName: bridgeserver2-db-prod
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-prod/BridgeHealthcodeRedisKey

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -13,11 +13,7 @@ parameters:
   AwsSnsBounceNotificationEndpoint: bridge-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgeops@sagebase.org
   BootstrapAdminEmail: !ssm /bridgeserver2-prod/BootstrapAdminEmail
-  BootstrapAdminPassword: !ssm /bridgeserver2-prod/BootstrapAdminPassword
-  BootstrapApiEmail: !ssm /bridgeserver2-prod/BootstrapApiEmail
-  BootstrapApiPassword: !ssm /bridgeserver2-prod/BootstrapApiPassword
-  BootstrapSharedEmail: !ssm /bridgeserver2-prod/BootstrapSharedEmail
-  BootstrapSharedPassword: !ssm /bridgeserver2-prod/BootstrapSharedPassword
+  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-prod/BootstrapAdminSynapseUserId
   BridgeEnv: prod
   BridgeDBStackName: bridgeserver2-db-prod
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-prod/BridgeHealthcodeRedisKey

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -12,6 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridge-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgeops@sagebase.org
+  BootstrapAdminEmail: !ssm /bridgeserver2-prod/BootstrapAdminEmail
   BootstrapAdminPassword: !ssm /bridgeserver2-prod/BootstrapAdminPassword
   BridgeEnv: prod
   BridgeDBStackName: bridgeserver2-db-prod

--- a/config/prod/bridgeserver2.yaml
+++ b/config/prod/bridgeserver2.yaml
@@ -12,8 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridge-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgeops@sagebase.org
-  BootstrapAdminEmail: !ssm /bridgeserver2-prod/BootstrapAdminEmail
-  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-prod/BootstrapAdminSynapseUserId
+  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
   BridgeEnv: prod
   BridgeDBStackName: bridgeserver2-db-prod
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-prod/BridgeHealthcodeRedisKey

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -12,8 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-uat-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
-  BootstrapAdminEmail: !ssm /bridgeserver2-uat/BootstrapAdminEmail
-  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-uat/BootstrapAdminSynapseUserId
+  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
   BridgeEnv: uat
   BridgeDBStackName: bridgeserver2-db-uat
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-uat/BridgeHealthcodeRedisKey

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -12,7 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-uat-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
-  BootstrapAdminPassword: !ssm /bridgeserver2-develop/BootstrapAdminPassword
+  BootstrapAdminPassword: !ssm /bridgeserver2-uat/BootstrapAdminPassword
   BridgeEnv: uat
   BridgeDBStackName: bridgeserver2-db-uat
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-uat/BridgeHealthcodeRedisKey

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -12,7 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-uat-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
-  BootstrapAdminEmail: !ssm /bridgeserver2-uat/Email
+  BootstrapAdminEmail: !ssm /bridgeserver2-uat/BootstrapAdminEmail
   BootstrapAdminPassword: !ssm /bridgeserver2-uat/BootstrapAdminPassword
   BridgeEnv: uat
   BridgeDBStackName: bridgeserver2-db-uat

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -13,11 +13,7 @@ parameters:
   AwsSnsBounceNotificationEndpoint: bridgepf-uat-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
   BootstrapAdminEmail: !ssm /bridgeserver2-uat/BootstrapAdminEmail
-  BootstrapAdminPassword: !ssm /bridgeserver2-uat/BootstrapAdminPassword
-  BootstrapApiEmail: !ssm /bridgeserver2-uat/BootstrapApiEmail
-  BootstrapApiPassword: !ssm /bridgeserver2-uat/BootstrapApiPassword
-  BootstrapSharedEmail: !ssm /bridgeserver2-uat/BootstrapSharedEmail
-  BootstrapSharedPassword: !ssm /bridgeserver2-uat/BootstrapSharedPassword
+  BootstrapAdminSynapseUserId: !ssm /bridgeserver2-uat/BootstrapAdminSynapseUserId
   BridgeEnv: uat
   BridgeDBStackName: bridgeserver2-db-uat
   BridgeHealthcodeRedisKey: !ssm /bridgeserver2-uat/BridgeHealthcodeRedisKey

--- a/config/uat/bridgeserver2.yaml
+++ b/config/uat/bridgeserver2.yaml
@@ -12,6 +12,7 @@ parameters:
   AwsEbHealthReportingSystem: enhanced
   AwsSnsBounceNotificationEndpoint: bridgepf-uat-bounce-notifications@sagebase.org
   AwsSnsNotificationEndpoint: bridgepf-uat@sagebase.org
+  BootstrapAdminEmail: !ssm /bridgeserver2-uat/Email
   BootstrapAdminPassword: !ssm /bridgeserver2-uat/BootstrapAdminPassword
   BridgeEnv: uat
   BridgeDBStackName: bridgeserver2-db-uat

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -29,19 +29,8 @@ Parameters:
     Description: Email address for AWS SNS notifications
   BootstrapAdminEmail:
     Type: String
-  BootstrapAdminPassword:
+  BootstrapAdminSynapseUserId:
     Type: String
-    NoEcho: true
-  BootstrapApiEmail:
-    Type: String
-  BootstrapApiPassword:
-    Type: String
-    NoEcho: true
-  BootstrapSharedEmail:
-    Type: String
-  BootstrapSharedPassword:
-    Type: String
-    NoEcho: true
   BridgeEnv:
     Type: String
     Default: dev
@@ -316,20 +305,8 @@ Resources:
           OptionName: admin.email
           Value: !Ref BootstrapAdminEmail
         - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: admin.password
-          Value: !Ref BootstrapAdminPassword
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: api.developer.email
-          Value: !Ref BootstrapApiEmail
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: api.developer.password
-          Value: !Ref BootstrapApiPassword
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: shared.developer.email
-          Value: !Ref BootstrapSharedEmail
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: shared.developer.password
-          Value: !Ref BootstrapSharedPassword
+          OptionName: admin.synapse.user.id
+          Value: !Ref BootstrapAdminSynapseUserId
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: ENV
           Value: !Ref Env

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -27,9 +27,7 @@ Parameters:
   AwsSnsNotificationEndpoint:
     Type: String
     Description: Email address for AWS SNS notifications
-  BootstrapAdminEmail:
-    Type: String
-  BootstrapAdminSynapseUserId:
+  BootstrapAdminPassword:
     Type: String
   BridgeEnv:
     Type: String
@@ -302,11 +300,8 @@ Resources:
           OptionName: aws.secret.key
           Value: !GetAtt AWSIAMBridgeServer2ServiceUserAccessKey.SecretAccessKey
         - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: admin.email
-          Value: !Ref BootstrapAdminEmail
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: admin.synapse.user.id
-          Value: !Ref BootstrapAdminSynapseUserId
+          OptionName: admin.password
+          Value: !Ref BootstrapAdminPassword
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: ENV
           Value: !Ref Env

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -27,8 +27,11 @@ Parameters:
   AwsSnsNotificationEndpoint:
     Type: String
     Description: Email address for AWS SNS notifications
+  BootstrapAdminEmail:
+    Type: String
   BootstrapAdminPassword:
     Type: String
+    NoEcho: true
   BridgeEnv:
     Type: String
     Default: dev
@@ -299,6 +302,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: aws.secret.key
           Value: !GetAtt AWSIAMBridgeServer2ServiceUserAccessKey.SecretAccessKey
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: admin.email
+          Value: !Ref BootstrapAdminEmail
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: admin.password
           Value: !Ref BootstrapAdminPassword


### PR DESCRIPTION
The additional bootstrap accounts are also no longer used and are removed.