### PR TITLE
BRIDGE-3174 Update Server2-infra to Corretto

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -184,7 +184,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !ImportValue us-east-1-bridgeserver2-common-BeanstalkAppName
-      SolutionStackName: '64bit Amazon Linux 2018.03 v3.4.10 running Tomcat 8.5 Java 8'
+      SolutionStackName: '64bit Amazon Linux 2 v4.2.11 running Tomcat 8.5 Corretto 8'
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'
@@ -264,6 +264,25 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:environment:process:default'
           OptionName: HealthCheckPath
           Value: !Ref AppHealthcheckUrl
+        - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
+          OptionName: ConfigDocument
+          Value: '{
+            "Rules": {
+              "Environment": {
+                "Application": {
+                  "ApplicationRequests4xx": {
+                    "Enabled": false
+                  }
+                },
+                "ELB": {
+                  "ELBRequests4xx": {
+                    "Enabled": false
+                  }
+                }
+              }
+            },
+            "Version": 1
+          }'
         - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
           OptionName: SystemType
           Value: !Ref AwsEbHealthReportingSystem


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3174

Updating the Elastic Beanstalk stack from Java 8 to Corretto 8 as Java 8 is no longer being supported by Elastic Beanstalk. This also updates to Amazon Linux 2, which requires a few changes with our configs and ebextensions.

For Server2-infra, the configs for Elastic Beanstalk to ignore 4XX errors in the health checks is now a ConfigDocument as an Elastic Beanstalk attribute.

This was tested on the Development stack.

Note: This requires Server changes (see also https://github.com/Sage-Bionetworks/BridgeServer2/pull/522) or else Bridge will fail to boot. Given this, I want to deploy this as a separate deployment Thursday night, after our regular deployment, in order to minimize risk.