### PR TITLE
Add EBS Role to KMS

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -959,6 +959,7 @@ Resources:
                     - ':root'
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !GetAtt AWSIAMBridgeServer2ServiceUser2.Arn
+                - !GetAtt AWSIAMRole.Arn
                 - !ImportValue us-east-1-bridgeserver2-common-BeanstalkServiceRoleArn
             Action:
               - "kms:Encrypt"


### PR DESCRIPTION
This is a pre-requisite for https://sagebionetworks.jira.com/browse/BRIDGE-3188

The AWS Role we use for Elastic Beanstalk needs all the same permissions that the AWS User we currently use. This includes KMS Keys.

There will be a future change to remove the AWS User from the Infra template, once everything is deployed and verified.