### PR TITLE
Redis (Elasticache) is now accessible through VPN

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -478,6 +478,7 @@ Resources:
       CacheNodeType: cache.t2.micro
       NumCacheNodes: 1
       VpcSecurityGroupIds:
+        - !ImportValue us-east-1-BridgeServer2-vpc-VpnSecurityGroup
         - !GetAtt ElasticacheSecurityGroup.GroupId
       CacheSubnetGroupName: !Ref ElasticacheSubnetGroup
   AWSEC2SecurityGroup:


### PR DESCRIPTION
This is needed for dev-ops. Redis isn't accessible at all, which can cause problems if we need to invalidate cached items or flush the cache entirely.

This change allows us to connect to Redis over VPN. (I've verified Redis is still inaccessible outside of the VPN.)