### PR TITLE
Revert "Redis (Elasticache) is now accessible through VPN"

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -478,7 +478,6 @@ Resources:
       CacheNodeType: cache.t2.micro
       NumCacheNodes: 1
       VpcSecurityGroupIds:
-        - !ImportValue us-east-1-BridgeServer2-vpc-VpnSecurityGroup
         - !GetAtt ElasticacheSecurityGroup.GroupId
       CacheSubnetGroupName: !Ref ElasticacheSubnetGroup
   AWSEC2SecurityGroup:


### PR DESCRIPTION
Reverts Sage-Bionetworks/BridgeServer2-infra#59

Reverting. Giving anyone on the VPN access to Elasticache would be overly broad. If this is needed again, we can look into how to restrict this further.