### PR TITLE
Scale up Elasticache to 2 nodes

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -480,6 +480,15 @@ Resources:
       VpcSecurityGroupIds:
         - !GetAtt ElasticacheSecurityGroup.GroupId
       CacheSubnetGroupName: !Ref ElasticacheSubnetGroup
+  ElasticacheReplicationGroup:
+    Type: 'AWS::ElastiCache::ReplicationGroup'
+    Properties:
+      ReplicationGroupDescription: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - ElasticacheReplicationGroup
+      PrimaryClusterId: !Ref ElasticacheCluster
+      ReplicasPerNodeGroup: 1
   AWSEC2SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
This is a pre-req to https://sagebionetworks.jira.com/browse/BRIDGE-3371

Scaling up to 2 nodes will minimize downtime when we update our Elasticache version.