### PR TITLE
Parameterize SQL version

### DIFF
--- a/config/develop/bridgeserver2-db.yaml
+++ b/config/develop/bridgeserver2-db.yaml
@@ -5,3 +5,4 @@ depedencies:
 parameters:
   HibernateConnectionPassword: !ssm /bridgeserver2-develop/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-develop/HibernateConnectionUsername
+  MySqlVersion: '5.7.mysql_aurora.2.11.0'

--- a/config/prod/bridgeserver2-db.yaml
+++ b/config/prod/bridgeserver2-db.yaml
@@ -7,3 +7,4 @@ parameters:
   DatabaseInstanceType: db.t2.medium
   HibernateConnectionPassword: !ssm /bridgeserver2-prod/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-prod/HibernateConnectionUsername
+  MySqlVersion: '5.6.10a'

--- a/config/uat/bridgeserver2-db.yaml
+++ b/config/uat/bridgeserver2-db.yaml
@@ -5,3 +5,4 @@ depedencies:
 parameters:
   HibernateConnectionPassword: !ssm /bridgeserver2-uat/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-uat/HibernateConnectionUsername
+  MySqlVersion: '5.6.10a'

--- a/templates/bridgeserver2-db.yaml
+++ b/templates/bridgeserver2-db.yaml
@@ -22,6 +22,8 @@ Parameters:
   HibernateConnectionUsername:
     Type: String
     NoEcho: true
+  MySqlVersion:
+    Type: String
 Resources:
   DBCluster:
     Type: AWS::RDS::DBCluster
@@ -37,7 +39,7 @@ Resources:
       DeletionProtection: true
       Engine: 'aurora'
       EngineMode: 'provisioned'
-      EngineVersion: '5.6.10a'
+      EngineVersion: !Ref MySqlVersion
       MasterUsername: !Ref HibernateConnectionUsername
       MasterUserPassword: !Ref HibernateConnectionPassword
       Port: 3306


### PR DESCRIPTION
This is related to https://sagebionetworks.jira.com/browse/BRIDGE-3370

We had a build failure https://app.travis-ci.com/github/Sage-Bionetworks/BridgeServer2-infra/jobs/594937027 This is because I had updated the MySQL version in dev, but I hadn't updated the CloudFormation template. This change parameterizes the MySQL version so that Dev will use the updated 5.7, but it won't affect Staging or Prod until the AWS issues are resolved.