### PR TITLE
Upgrade Staging MySQL version

### DIFF
--- a/config/local/bridgeserver2-antivirus.yaml
+++ b/config/local/bridgeserver2-antivirus.yaml
@@ -1,0 +1,7 @@
+template_path: bridgeserver2-antivirus.yaml
+stack_name: bridgeserver2-antivirus-local-djeng
+parameters:
+  CodeZipS3BucketParameter: org-sagebridge-deployments-devdevelop
+  CodeZipS3KeyParameter: virus-scanner-lambda-20230206-af70cfc.zip
+  ScanTriggerSNSTopicArn: arn:aws:sns:us-east-1:420786776710:virus-scan-trigger-devlocal-dwaynejeng
+  ScanResultSNSTopicArn: arn:aws:sns:us-east-1:420786776710:virus-scan-result-devlocal-dwaynejeng

--- a/config/local/bridgeserver2-antivirus.yaml
+++ b/config/local/bridgeserver2-antivirus.yaml
@@ -1,7 +1,0 @@
-template_path: bridgeserver2-antivirus.yaml
-stack_name: bridgeserver2-antivirus-local-djeng
-parameters:
-  CodeZipS3BucketParameter: org-sagebridge-deployments-devdevelop
-  CodeZipS3KeyParameter: virus-scanner-lambda-20230206-af70cfc.zip
-  ScanTriggerSNSTopicArn: arn:aws:sns:us-east-1:420786776710:virus-scan-trigger-devlocal-dwaynejeng
-  ScanResultSNSTopicArn: arn:aws:sns:us-east-1:420786776710:virus-scan-result-devlocal-dwaynejeng

--- a/config/uat/bridgeserver2-db.yaml
+++ b/config/uat/bridgeserver2-db.yaml
@@ -5,4 +5,4 @@ depedencies:
 parameters:
   HibernateConnectionPassword: !ssm /bridgeserver2-uat/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-uat/HibernateConnectionUsername
-  MySqlVersion: '5.6.10a'
+  MySqlVersion: '5.7.mysql_aurora.2.11.1'


### PR DESCRIPTION
Related to https://sagebionetworks.jira.com/browse/BRIDGE-3370

This is needed because the staging MySQL database has already been updated, and the Infra deployment will fail if we don't change it here.

Note that the version for uat is different from the version for dev. This is because the uat deployment has been failing for the last 3 weeks, and I didn't expect it to succeed, so I picked the latest 5.7 version without realizing that it was different. It's possible that it succeeded only *because* it was a different version.

In any case, I made a note in the Jira to put prod on ‘5.7.mysql_aurora.2.11.1’ to be consistent with uat, and to upgrade dev to the same version. (It should be quick because it’s a minor version.) Will send another update next week when prod is upgraded and dev is bumped to the correct minor version.