### PR TITLE
Update MySQL and Elasticache (Redis) versions

### DIFF
--- a/config/develop/bridgeserver2-db.yaml
+++ b/config/develop/bridgeserver2-db.yaml
@@ -5,4 +5,4 @@ depedencies:
 parameters:
   HibernateConnectionPassword: !ssm /bridgeserver2-develop/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-develop/HibernateConnectionUsername
-  MySqlVersion: '5.7.mysql_aurora.2.11.0'
+  MySqlVersion: '5.7.mysql_aurora.2.11.1'

--- a/config/prod/bridgeserver2-db.yaml
+++ b/config/prod/bridgeserver2-db.yaml
@@ -7,4 +7,4 @@ parameters:
   DatabaseInstanceType: db.t2.medium
   HibernateConnectionPassword: !ssm /bridgeserver2-prod/HibernateConnectionPassword
   HibernateConnectionUsername: !ssm /bridgeserver2-prod/HibernateConnectionUsername
-  MySqlVersion: '5.6.10a'
+  MySqlVersion: '5.7.mysql_aurora.2.11.1'

--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -487,6 +487,8 @@ Resources:
         - '-'
         - - !Ref 'AWS::StackName'
           - ElasticacheReplicationGroup
+      AutomaticFailoverEnabled: false
+      EngineVersion: '6.0'
       PrimaryClusterId: !Ref ElasticacheCluster
       ReplicasPerNodeGroup: 1
   AWSEC2SecurityGroup:


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3370 - Upgrade MySQL to 5.7

This needed to be done outside of CloudFormation because CloudFormation doesn't support Blue/Green deployments. Now that this is done, change the version in our CF templates for consistency.

https://sagebionetworks.jira.com/browse/BRIDGE-3371 - Upgrade Elasticache

Dev and Staging are already on 6.0.5 (which in CloudFormation is just "6.0"). Prod is still on 5.0.4. Because the templates don't specify version, CloudFormation automatically chooses the latest, which is why Dev and Staging are on a different version. This syncs up the versions and pushes out an update for Prod.

We have to specify AutomaticaFailoverEnabled: false, because CloudFormation won't let us update if this is set to true.