### PR TITLE
Add alarm if Antivirus Scanner Lambda is throttling

### DIFF
--- a/templates/bridgeserver2-antivirus.yaml
+++ b/templates/bridgeserver2-antivirus.yaml
@@ -170,6 +170,23 @@ Resources:
             - '-'
             - - !Ref 'AWS::StackName'
               - ErrorCount
+  VirusScannerLambdaThrottlingAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref VirusScannerLambdaAlarmTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref VirusScannerLambda
+      EvaluationPeriods: 1
+      MetricName: Throttles
+      Namespace: AWS/Lambda
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
   VirusScanDefinitionUpdaterLambda:
     Type: 'AWS::Lambda::Function'
     Properties:


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3387

Lambda throttles if we have too many concurrent requests (over 1000 account-wide, according to the docs). This sets up an alarm so that we know if it happens.