### PR TITLE
Suppress FileNotFound exceptions from Antivirus error alarm

### DIFF
--- a/templates/bridgeserver2-antivirus.yaml
+++ b/templates/bridgeserver2-antivirus.yaml
@@ -161,7 +161,7 @@ Resources:
         - ''
         - - /aws/lambda/
           - !Ref VirusScannerLambda
-      FilterPattern: 'ERROR'
+      FilterPattern: 'ERROR -"Not Found" -NoSuchKey -MethodNotAllowed'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
As it turns out, the vast majority of errors from the antivirus is because Integ Tests upload a file (generally the consent doc when a Subpopulation is created), and then deletes it before the antivirus can get around to scanning it.

Since these errors are not actionable, and since the error messages are rather noisy, I'm going ahead and suppressing them.

For more documentation around antivirus error messages, see https://sagebionetworks.jira.com/wiki/spaces/PLFM/pages/535953411/Virus+Scanning+of+Files#VirusScanningofFiles-ErrorMessages