### PR TITLE
increase storage from 8gb to 16gb

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -199,6 +199,12 @@ Resources:
           OptionName: InstanceType
           Value: !Ref EC2InstanceType
         - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeType
+          Value: gp3
+        - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeSize
+          Value: '16'
+        - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: SecurityGroups
           Value: !Ref AWSEC2SecurityGroup
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'


### PR DESCRIPTION
Our Prod servers are running out of disk space and failing. This change upgrade our disks from 8gb to 16gb and upgrades them from gp2 to the gp3, which is newer, cheaper, and performs better.