### PR TITLE
Increase Xmx to 3.5G out of 4G

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -259,7 +259,7 @@ Resources:
           Value: '-Dnewrelic.config.file=/etc/newrelic.yml -javaagent:/usr/local/lib/newrelic/newrelic-agent.jar'
         - Namespace: 'aws:elasticbeanstalk:container:tomcat:jvmoptions'
           OptionName: Xmx
-          Value: '2048m'
+          Value: '3584m'
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
           Value: !ImportValue us-east-1-bridgeserver2-common-BeanstalkServiceRole


### PR DESCRIPTION
Increasing from 2G to 3G drastically reduced the number of connection reset failures. Increase again for further reduction, leaving 512M of RAM overhead for the rest of the system.