### PR TITLE
[IT-5072] Update EB Solution Stack (again)

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -190,7 +190,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !ImportValue us-east-1-bridgeserver2-common-BeanstalkAppName
-      SolutionStackName: '64bit Amazon Linux 2 v4.13.3 running Tomcat 9 Corretto 8'
+      SolutionStackName: '64bit Amazon Linux 2 v4.14.0 running Tomcat 9 Corretto 8'
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'


### PR DESCRIPTION
AWS rotated the available platform versions before we could promote our update to prod. Roll through another stack update.