### PR TITLE
[IT-5167] Migrate from AL2 to AL2023

### DIFF
--- a/templates/bridgeserver2.yaml
+++ b/templates/bridgeserver2.yaml
@@ -190,7 +190,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !ImportValue us-east-1-bridgeserver2-common-BeanstalkAppName
-      SolutionStackName: '64bit Amazon Linux 2 v4.14.0 running Tomcat 9 Corretto 8'
+      SolutionStackName: '64bit Amazon Linux 2023 v5.14.2 running Tomcat 9 Corretto 8'
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'


### PR DESCRIPTION
The Amazon Linux 2 platforms will be deprecated by AWS on June 30th 2026. Migrate to the Amazon Linux 2023 platform.